### PR TITLE
Production実行時に.envが読めなくて詰むお話を解決

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN go build -o RecommendSystem main.go
 
 FROM alpine:3.9 as release
 WORKDIR /apps
+COPY --from=build /go/src/.env /apps/
 COPY --from=build /go/src/RecommendSystem /usr/local/bin/RecommendSystem
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/RecommendSystem"]

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -6,7 +6,5 @@ services:
       target: release
     environment:
       - GO_ENV=production
-    volumes:
-      - ./:/go/src
     ports:
       - "8087:8080"


### PR DESCRIPTION
SPA脳のせいで、`go build`するときに`.env`も組み込んでバイナリ化すると思い込んでたら、実は違ったらしい（実行時のカレントディレクトリに置かなきゃいけない）。

まあそりゃ、ソースコード上は*ファイルを読み込む*って動作しかしてないんだもんな。うん。

……本来はどうするべきかは置いといて、とりあえず動くように修正
